### PR TITLE
Update example to user varset instead of identity token

### DIFF
--- a/deployments.tfdeploy.hcl
+++ b/deployments.tfdeploy.hcl
@@ -9,7 +9,7 @@ store "varset" "gcp_credentials" {
 deployment "production" {
   inputs = {
     public_ssh_key_url = "<Set to a URL where your public SSH key can be read. Used for compute instance login auth>"
-    google_credentials = store.varset.gcp_credentials.credentials
+    gcp_credentials    = store.varset.gcp_credentials.credentials
     gcp_project_id     = "<Set to your GCP project ID>"
     gcp_region         = "us-central1"
     gcp_zone           = "us-central1-a"

--- a/deployments.tfdeploy.hcl
+++ b/deployments.tfdeploy.hcl
@@ -1,19 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-identity_token "gcp" {
-  # Must be the fully qualified path to the identity provider: //iam.googleapis.com/projects/<PROJECT NUMBER>/locations/global/workloadIdentityPools/<POOL ID>/providers/<PROVIDER ID>
-  audience = ["<Set to your GCP token audience>"]
+store "varset" "gcp_credentials" {
+    id       = "<Set to a varset ID that contains GCP credentials>"
+    category = "terraform"
 }
 
 deployment "production" {
   inputs = {
-    public_ssh_key_url         = "<Set to a URL where your public SSH key can be read. Used for compute instance login auth>"
-    identity_token_file        = identity_token.gcp.jwt_filename
-    gcp_audience               = "<Set to your GCP token audience>"
-    gcp_service_account_email  = "<Set to your GCP service account email>"
-    gcp_project_id             = "<Set to your GCP project ID>"
-    gcp_region                 = "us-central1"
-    gcp_zone                   = "us-central1-a"
+    public_ssh_key_url = "<Set to a URL where your public SSH key can be read. Used for compute instance login auth>"
+    google_credentials = store.varset.gcp_credentials.credentials
+    gcp_project_id     = "<Set to your GCP project ID>"
+    gcp_region         = "us-central1"
+    gcp_zone           = "us-central1-a"
   }
 }

--- a/providers.tfstack.hcl
+++ b/providers.tfstack.hcl
@@ -15,21 +15,10 @@ required_providers {
 
 provider "google" "this" {
   config {
-    project = var.gcp_project_id
-    region  = var.gcp_region
-    zone    = var.gcp_zone
-    credentials = jsonencode(
-      {
-        "type": "external_account",
-        "audience": var.gcp_audience,
-        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-        "token_url": "https://sts.googleapis.com/v1/token",
-        "credential_source": {
-          "file": var.identity_token_file
-        },
-        "service_account_impersonation_url": format("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", var.gcp_service_account_email)
-      }
-    )
+    project     = var.gcp_project_id
+    region      = var.gcp_region
+    zone        = var.gcp_zone
+    credentials = var.gcp_credentials
   }
 }
 

--- a/variables.tfstack.hcl
+++ b/variables.tfstack.hcl
@@ -1,21 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-variable "identity_token_file" {
-  type = string
-}
-
 variable "public_ssh_key_url" {
   type = string
 }
 
-variable "gcp_audience" {
-  type = string
-  description = "The fully qualified GCP identity provider name, e.g. '//iam.googleapis.com/projects/270867328173/locations/global/workloadIdentityPools/my-tfc-pool/providers/the-tfc-provider'. This is the same audience value as you've configured in the identity_token block. Google requires this audience value to be set in the service account file itself as well as the token claim."
-}
-
-variable "gcp_service_account_email" {
-  type = string
+variable "gcp_credentials" {
+  type      = string
+  ephemeral = true
 }
 
 variable "gcp_project_id" {


### PR DESCRIPTION
We're about to deprecate the `jwt_filename` part of the identity token. This means we have to use varset credentials to authenticate with GCP while we wait for the provider to implement direct JWTs.